### PR TITLE
Feature/#4 Cookie の保存・読み出し

### DIFF
--- a/api/appdata.go
+++ b/api/appdata.go
@@ -18,9 +18,9 @@ func configDirPath() (string, error) {
 	return path.Join(configDir, "cvpn"), nil
 }
 
-// ChacheDirPath は cvpn のキャッシュデータを格納するユーザディレクトリの絶対パスを返す。
+// cacheDirPath は cvpn のキャッシュデータを格納するユーザディレクトリの絶対パスを返す。
 // Linux ならおそらく一般的に ~/.cache 。
-func chacheDirPath() (string, error) {
+func cacheDirPath() (string, error) {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
 		return "", err
@@ -30,7 +30,7 @@ func chacheDirPath() (string, error) {
 
 // cookieCacheFilePath はクッキーを保存するファイルの絶対パスを返す。
 func cookieFilePath() (string, error) {
-	cacheDir, err := chacheDirPath()
+	cacheDir, err := cacheDirPath()
 	if err != nil {
 		return "", err
 	}
@@ -39,7 +39,7 @@ func cookieFilePath() (string, error) {
 
 // saveCookies は cookies を cookieFilePath() で示されるパスのファイルへ書き込む。
 // ファイルはまず空になったあとで書き込まれる。
-// 保存形式や保存先ファイル名は規定しない。読み出しは leadCookies を用いること。
+// 保存形式や保存先ファイル名は規定しない。読み出しは loadCookies を用いること。
 func saveCookies(cookies []string) error {
 	cookieFilePath, err := cookieFilePath()
 	if err != nil {

--- a/api/appdata.go
+++ b/api/appdata.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"path"
+)
+
+// ConfigDirPath は cvpn の設定データを格納するユーザディレクトリの絶対パスを返す。
+// Linux ならおそらく一般的に ~/.config 。
+func configDirPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(configDir, "cvpn"), nil
+}
+
+// ChacheDirPath は cvpn のキャッシュデータを格納するユーザディレクトリの絶対パスを返す。
+// Linux ならおそらく一般的に ~/.cache 。
+func chacheDirPath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(cacheDir, "cvpn"), nil
+}
+
+// cookieCacheFilePath はクッキーを保存するファイルの絶対パスを返す。
+func cookieFilePath() (string, error) {
+	cacheDir, err := chacheDirPath()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(cacheDir, "cookies.txt"), nil
+}
+
+// saveCookies は cookies を cookieFilePath() で示されるパスのファイルへ書き込む。
+// ファイルはまず空になったあとで書き込まれる。
+// 保存形式や保存先ファイル名は規定しない。読み出しは leadCookies を用いること。
+func saveCookies(cookies []string) error {
+	cookieFilePath, err := cookieFilePath()
+	if err != nil {
+		return err
+	}
+
+	// MkdirAll は mkdir -p と同じ効果。ディレクトリが既に存在してもエラーを返さない。
+	if err := os.MkdirAll(path.Dir(cookieFilePath), 0700); err != nil {
+		return err
+	}
+
+	fp, err := os.OpenFile(cookieFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	for _, cookie := range cookies {
+		fmt.Fprintln(fp, cookie)
+	}
+	log.Printf("saveCookies(): Saved %d lines of cookie into %q.\n", len(cookies), cookieFilePath)
+	return nil
+}
+
+// loadCookies は saveCookies() で書き出されたクッキー群を読み出して返す。
+func loadCookies() ([]string, error) {
+	cookieFilePath, err := cookieFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	fp, err := os.Open(cookieFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer fp.Close()
+
+	cookies := make([]string, 0, 5)
+	scanner := bufio.NewScanner(fp)
+	for scanner.Scan() {
+		cookie := scanner.Text()
+		cookies = append(cookies, cookie)
+	}
+
+	log.Printf("loadCookies(): Loaded %d lines of cookie.\n", len(cookies))
+	return cookies, nil
+}
+
+func deleteCookieFile() error {
+	cookieFilePath, err := cookieFilePath()
+	if err != nil {
+		return err
+	}
+	log.Println("deleteCookieFile(): delete.")
+	return os.Remove(cookieFilePath)
+}

--- a/api/auth.go
+++ b/api/auth.go
@@ -17,7 +17,7 @@ func (c *Client) Login(username string, password string) error {
 		return err
 	}
 
-	_, err := c.getAuthParms()
+	_, err := c.getAuthParams()
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (c *Client) login(username, password string) error {
 	return nil
 }
 
-func (c *Client) getAuthParms() (map[string][]string, error) {
+func (c *Client) getAuthParams() (map[string][]string, error) {
 	req, err := http.NewRequest(http.MethodGet, VpnIndexURL, nil)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func (c *Client) LoadCookiesOrLogin(username, password string) error {
 	c.cookies = cookies
 
 	// ファイルから読み込んだクッキーで getAuthParms() が成功したなら return
-	_, err = c.getAuthParms()
+	_, err = c.getAuthParams()
 	if err == nil {
 		log.Println("LoadCookiesOrLogin(): Succeeded getAuthParms() with saved cookie.")
 		return nil

--- a/api/auth.go
+++ b/api/auth.go
@@ -72,6 +72,9 @@ func (c *Client) getAuthParms() (map[string][]string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		if isRedirectedToLogin(resp) {
+			return nil, &ErrRedirectedToLogin{NextPath: resp.Header.Get("location"), PrevPath: req.URL.RawPath}
+		}
 		return nil, errors.New("Error: Status code was not OK")
 	}
 

--- a/api/auth.go
+++ b/api/auth.go
@@ -22,6 +22,10 @@ func (c *Client) Login(username string, password string) error {
 		return err
 	}
 
+	if err := saveCookies(c.cookies); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -152,6 +156,7 @@ func (c *Client) Logout() error {
 		return errors.New("failed to logout")
 	}
 
+	_ = deleteCookieFile()
 	return nil
 }
 

--- a/api/common.go
+++ b/api/common.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 )
@@ -44,4 +45,25 @@ func (c *Client) request(r *http.Request) (*http.Response, error) {
 	resp, err := c.client.Do(r)
 
 	return resp, err
+}
+
+type ErrRedirectedToLogin struct {
+	NextPath string // リダイレクト先のURLパス
+	PrevPath string // リダイレクト元のURLパス
+}
+
+func (err *ErrRedirectedToLogin) Error() string {
+	return fmt.Sprintf("Err: Redirected to login %q (previous: %q)",
+		err.NextPath, err.PrevPath)
+}
+
+func isRedirectedToLogin(resp *http.Response) bool {
+	if resp.StatusCode != http.StatusFound {
+		return false
+	}
+	location, err := resp.Location()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(location.String(), "/dana-na/auth/")
 }

--- a/cmd/cvpn/main.go
+++ b/cmd/cvpn/main.go
@@ -20,7 +20,13 @@ func main() {
 	fmt.Println(username, password)
 
 	client := api.NewClient()
-	if err := client.Login(username, password); err != nil {
+	if err := client.LoadCookiesOrLogin(username, password); err != nil {
 		log.Fatal(err)
 	}
+
+	// if err := client.Logout(); err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	fmt.Println("All success. exit 0.")
 }


### PR DESCRIPTION
## 概要・変更点
- Cookie を `os.UserCacheDir()` + `/cvpn/cookies.txt` に保存する関数の追加
- Cookie を読み出す関数の追加
- Cookie を読み出して、読み出した Cookie が無効な場合にのみ `Login()` する関数の追加
- `Login()` 内部に、ログイン成功後に Cookie を保存する処理を追加 (`Login()` 内部ですべきではなかったかも)

## 自分が検証した動作
- Cookie のファイル書込み・読み込みが正常に実行されること
- ファイルから読み出した Cookie が有効な場合は Login() しないこと
- ファイルから読み出した Cookie が無効な場合 or Cookie のファイルが無い場合は自動で Login() すること
- キャッシュディレクトリのパーミッションが 700, Cookie ファイルのパーミッションが 600 であること
