### PR TITLE
Feature/#9 choose session

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -18,6 +18,9 @@ func TestLogin(t *testing.T) {
 		switch err.(type) {
 		case *SessionError:
 			// セッションエラーだからセッションを選ばせればいい
+			if err := client.ConfirmSession(true); err != nil {
+				t.Fatal(err)
+			}
 		default:
 			t.Fatal(err)
 		}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -8,6 +8,22 @@ import (
 	"github.com/joho/godotenv"
 )
 
+func TestLogin(t *testing.T) {
+	if err := godotenv.Load("../.env"); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewClient()
+	if err := client.LoadCookiesOrLogin(os.Getenv("SVPN_USERNAME"), os.Getenv("SVPN_PASSWORD")); err != nil {
+		switch err.(type) {
+		case *SessionError:
+			// セッションエラーだからセッションを選ばせればいい
+		default:
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestDownload(t *testing.T) {
 	if err := godotenv.Load("../.env"); err != nil {
 		t.Fatal(err)

--- a/api/auth.go
+++ b/api/auth.go
@@ -29,6 +29,12 @@ func (c *Client) Login(username string, password string) error {
 	return nil
 }
 
+type SessionError struct{}
+
+func (se *SessionError) Error() string {
+	return "Error: Session Error. You have to choose session"
+}
+
 func (c *Client) login(username, password string) error {
 	const (
 		LoginEndpoint = "https://vpn.inf.shizuoka.ac.jp/dana-na/auth/url_3/login.cgi"
@@ -58,7 +64,7 @@ func (c *Client) login(username, password string) error {
 	case LoginSucceed:
 		c.cookies = getCookies(resp.Header["Set-Cookie"])
 	case LoginFailed:
-		return errors.New("Error: Login Failed")
+		return &SessionError{}
 	default: // confirm session
 		return errors.New("Oops! You should choose session(todo)")
 	}

--- a/api/auth.go
+++ b/api/auth.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (c *Client) Login(username string, password string) error {
-	var params url.Values
+	params := make(url.Values)
 
 	params.Set("tz_offset", "540")
 	params.Set("username", username)

--- a/api/auth.go
+++ b/api/auth.go
@@ -93,7 +93,7 @@ func (c *Client) getAuthParams() (url.Values, error) {
 		return nil, err
 	}
 
-	var params url.Values
+	params := make(url.Values)
 
 	params.Set("xsauth", xsauth)
 
@@ -197,7 +197,21 @@ func (c *Client) ConfirmSession(ok bool) error {
 	}()
 	params["FormDataStr"] = []string{formDataStr}
 
-	return c.login(params)
+	if err := c.login(params); err != nil {
+		return err
+	}
+
+	authParams, err := c.getAuthParams()
+	if err != nil {
+		return err
+	}
+	c.authParams = authParams
+
+	if err := saveCookies(c.cookies); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func findFormDataStr(doc *goquery.Document) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/PuerkitoBio/goquery v1.6.1
+	github.com/joho/godotenv v1.3.0
 	github.com/spf13/cobra v1.1.3
 )

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=


### PR DESCRIPTION
resolve: #9 (api のみ)

# 概要
セッション選択 api を実装しました。これにより、ブラウザでログインしている状態で `cvpn` でログインをしてもセッションの選択をすることができるようになります。

# 変更点
+ `map[string][]string` を `url.Value` に変更(一部)
+ セッションエラーが発生したときに `SessionError` 構造体を返すように(エラーの識別ができるようになる)

# テスト
1. ブラウザの vpn サービスでログインをする
2. `$ go test -v -run TestLogin github.com/Shizuoka-Univ-dev/cvpn/api -count=1` を実行(`cvpn` でのセッションを続行する)
3. `$ go test -v -run TestDownload github.com/Shizuoka-Univ-dev/cvpn/api -count=1` を実行し、`api/` に `makabe.png` がダウンロードされていることを確認(`cs20097/` なので permission denied になるかも)