### PR TITLE
Feature/#1 download command

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -39,7 +39,7 @@ func TestDownload(t *testing.T) {
 
 	const (
 		targetPath = "/cs20097/makabe.png"
-		savePath   = ""
+		savePath   = "."
 		volumeID   = VolumeIDFS + "2020"
 	)
 	if err := client.Download(

--- a/api/common.go
+++ b/api/common.go
@@ -17,11 +17,6 @@ const (
 	VpnIndexURL = "https://vpn.inf.shizuoka.ac.jp/dana/home/index.cgi"
 )
 
-const (
-	VolumeIDFSShare = "resource_1423533946.487706.3"
-	VolumeIDFS      = "resource_1389773645.177066.2," // resource_1389773645.177066.2,2020 とか
-)
-
 type Client struct {
 	client     *http.Client
 	cookies    []string

--- a/api/volume.go
+++ b/api/volume.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	VolumeIDFSShare = "resource_1423533946.487706.3"
+	VolumeIDFS      = "resource_1389773645.177066.2," // resource_1389773645.177066.2,2020 とか
+)
+
+const (
+	VolumeNameFSShare = "fsshare"
+	VolumeNameFS      = "fs"
+)
+
+var VolumeMap = map[string]string{
+	VolumeNameFSShare: VolumeIDFSShare,
+	VolumeNameFS:      VolumeIDFS,
+}
+
+func GetVolumeIDFromName(name string) (string, error) {
+	if name == VolumeNameFSShare {
+		return VolumeIDFSShare, nil
+	}
+
+	if len(name) >= 2 && name[:2] == VolumeNameFS {
+		tokens := strings.Split(name, "/")
+		if len(tokens) < 2 {
+			return "", errors.New("invalid fs volume format. example: -v fs/2020")
+		}
+
+		return VolumeIDFS + tokens[1], nil
+	}
+
+	return "", errors.New("no such volume. please try fs/{any} or fsshare")
+}


### PR DESCRIPTION
# 使い方

```console
$ cvpn download {target_path} -o {save_path} -v {volume_name}

example
$ cvpn download /cs20097/makabe.png -o ~/Image -v fs/2020
```

+ `{target_path}`: ダウンロードしたいファイルのパス
+ `{save_path}`: 保存先のパス
+ `{volume_name}`: `fs/{any}` or `fsshare`

# 変更点
+ download api の仕様を少し変更(`savePath` の指定が必須になった)

# お気持ち
`{volume_name}` はこの仕様で固めたい