### PR TITLE
feat: ダウンロード対象ファイルが存在しない場合のエラーチェックを実装

### DIFF
--- a/api/download.go
+++ b/api/download.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -61,6 +62,19 @@ func (c *Client) downloadFile(reqURL, fileName, dirPath string, params *url.Valu
 		return err
 	}
 	defer file.Close()
+
+    // ダウンロード対象のファイルが存在しない場合は HTML で エラーメッセージが返ってくる
+    if strings.Contains(resp.Header.Get("Content-Type"), "html") {
+        const fileNotFoundMessage = "The file or folder does not exist on the server. Please contact your system administrator."
+        tee := io.TeeReader(resp.Body, file)
+        htmlBytes, err := io.ReadAll(tee)
+        if err != nil {
+            return err
+        }
+        if bytes.Contains(htmlBytes, []byte(fileNotFoundMessage)) {
+            return fmt.Errorf("File does not found. You may wrong the argument `path` or `volume`.")
+        }
+    }
 
 	n, err := io.Copy(file, resp.Body)
 	if err != nil {


### PR DESCRIPTION
## 変更内容
- ダウンロード時の、パスorボリュームが見つからないときのエラーチェックを実装

## ダウンロード対象のファイルが存在しないかどうかの判定方法
エラーメッセージが含まれた HTML が返ってくる。 そのエラーメッセージが含まれているかどうかで判定した。

エラーメッセージ有無チェック用の読み込みと `io.Copy(file, ...)` 用の読み込み で2回読み込みが必要になるので、 `io.TeeReader` を使った。