### PR TITLE
refactor: use *log.Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ $ cvpn find /cs200xx -v fs/2020 -name hogehoge
 |名前|`hoge.pdf`|
 |パス|`/class/english/hoge.pdf`|
 
+### Log
+
+ログは `$USER_CACHE_DIR/cvpn/log/` 配下に保存されます。  
+`$USER_CACHE_DIR` は OS によって異なるので、詳しい内容は https://golang.org/pkg/os/#UserCacheDir を参照してください。
+
 ### Development
 
 開発者向けの内容です。

--- a/api/appdata.go
+++ b/api/appdata.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bufio"
 	"fmt"
-	"log"
 	"os"
 	"path"
 )
@@ -62,7 +61,7 @@ func saveCookies(cookies []string) error {
 	for _, cookie := range cookies {
 		fmt.Fprintln(fp, cookie)
 	}
-	log.Printf("saveCookies(): Saved %d lines of cookie into %q.\n", len(cookies), cookieFilePath)
+	logger.Printf("saveCookies(): Saved %d lines of cookie into %q.\n", len(cookies), cookieFilePath)
 	return nil
 }
 
@@ -86,7 +85,7 @@ func loadCookies() ([]string, error) {
 		cookies = append(cookies, cookie)
 	}
 
-	log.Printf("loadCookies(): Loaded %d lines of cookie.\n", len(cookies))
+	logger.Printf("loadCookies(): Loaded %d lines of cookie.\n", len(cookies))
 	return cookies, nil
 }
 
@@ -95,6 +94,6 @@ func deleteCookieFile() error {
 	if err != nil {
 		return err
 	}
-	log.Println("deleteCookieFile(): delete.")
+	logger.Printf("deleteCookieFile(): delete.")
 	return os.Remove(cookieFilePath)
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -4,7 +4,6 @@ package api
 
 import (
 	"errors"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -103,7 +102,7 @@ func (c *Client) getAuthParams() (url.Values, error) {
 func (c *Client) LoadCookiesOrLogin(username, password string) error {
 	cookies, err := loadCookies()
 	if err != nil || len(cookies) == 0 {
-		log.Println("LoadCookiesOrLogin(): Trying login due to no cookie.")
+		logger.Printf("LoadCookiesOrLogin(): Trying login due to no cookie.")
 		return c.Login(username, password)
 	}
 	c.cookies = cookies
@@ -112,13 +111,13 @@ func (c *Client) LoadCookiesOrLogin(username, password string) error {
 	authParams, err := c.getAuthParams()
 	if err == nil {
 		c.authParams = authParams
-		log.Println("LoadCookiesOrLogin(): Succeeded getAuthparams() with saved cookie.")
+		logger.Printf("LoadCookiesOrLogin(): Succeeded getAuthparams() with saved cookie.")
 		return nil
 	}
 
 	switch err.(type) {
 	case *ErrRedirectedToLogin:
-		log.Println("LoadCookiesOrLogin(): Trying login due to invalid cookie.")
+		logger.Printf("LoadCookiesOrLogin(): Trying login due to invalid cookie.")
 		return c.Login(username, password)
 	default:
 		return err

--- a/api/common.go
+++ b/api/common.go
@@ -3,8 +3,10 @@
 package api
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,6 +19,11 @@ const (
 	VpnIndexURL = "https://vpn.inf.shizuoka.ac.jp/dana/home/index.cgi"
 )
 
+var (
+	logger *log.Logger
+	buffer bytes.Buffer
+)
+
 type Client struct {
 	client     *http.Client
 	cookies    []string
@@ -26,6 +33,8 @@ type Client struct {
 func NewClient() *Client {
 	client := new(http.Client)
 
+	logger = log.New(&buffer, "[CVPN-API]", log.Default().Flags())
+
 	// redirect をしない
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
@@ -34,6 +43,10 @@ func NewClient() *Client {
 	return &Client{
 		client: client,
 	}
+}
+
+func ReadLog() []byte {
+	return buffer.Bytes()
 }
 
 // 認証情報を含めたリクエストを送る。

--- a/pkg/subcmd/common.go
+++ b/pkg/subcmd/common.go
@@ -14,6 +14,9 @@ func Execute() {
 	cmd.SetOutput(os.Stdout)
 
 	if err := cmd.Execute(); err != nil {
+		if err := saveLogs(); err != nil {
+			log.Fatal(err)
+		}
 		cmd.SetOutput(os.Stderr)
 		cmd.Println(err)
 		os.Exit(1)

--- a/pkg/subcmd/common.go
+++ b/pkg/subcmd/common.go
@@ -1,6 +1,13 @@
 package subcmd
 
-import "os"
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Shizuoka-Univ-dev/cvpn/api"
+)
 
 func Execute() {
 	cmd := NewRootCmd()
@@ -12,4 +19,31 @@ func Execute() {
 		os.Exit(1)
 	}
 
+	if err := saveLogs(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func saveLogs() error {
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return err
+	}
+	logDirPath := filepath.Join(userCacheDir, "cvpn", "log")
+	_ = os.MkdirAll(logDirPath, 0755)
+
+	logNameFormat := "2006-01-02_15-04-05.log"
+	logName := time.Now().Format(logNameFormat)
+
+	file, err := os.Create(filepath.Join(logDirPath, logName))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	if _, err := file.Write(api.ReadLog()); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
log を `$USER_CACHE_DIR/cvpn/log/` に置くようにしました。
ただ、log の出力をやめるとログインに時間がかかった時にユーザーが困惑するというのはそれはそうなので要協議です。