### PR TITLE
cvpn login のバグを修正

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -124,6 +124,25 @@ func (c *Client) LoadCookiesOrLogin(username, password string) error {
 	}
 }
 
+func (c *Client) CheckCookies() bool {
+	cookies, err := loadCookies()
+	if err != nil || len(cookies) == 0 {
+		logger.Printf("LoadCookiesOrLogin(): Trying login due to no cookie.")
+		return false
+	}
+	c.cookies = cookies
+
+	// ファイルから読み込んだクッキーで getAuthparams() が成功したなら return
+	authParams, err := c.getAuthParams()
+	if err == nil {
+		c.authParams = authParams
+		logger.Printf("LoadCookiesOrLogin(): Succeeded getAuthparams() with saved cookie.")
+		return true
+	}
+
+	return false
+}
+
 func (c *Client) Logout() error {
 	const LogoutEndpoint = "https://vpn.inf.shizuoka.ac.jp/dana-na/auth/logout.cgi"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 )
 
 //JSON用の構造体
@@ -17,13 +18,10 @@ type Config struct {
 func LoadConfig() (Config, error) {
 
 	//ConfigDirPathを取得
-	configDir, err := os.UserConfigDir()
+	configFilePath, err := ConfigPath()
 	if err != nil {
 		return Config{}, err
 	}
-
-	// ConfigFilePath（configFileを書き込むパス）の設定
-	configFilePath := path.Join(configDir, "cvpn/config.json")
 
 	jsonFile, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
@@ -38,4 +36,40 @@ func LoadConfig() (Config, error) {
 
 	//username,password
 	return data, nil
+}
+
+func ConfigPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	return path.Join(configDir, "cvpn", "config.json"), nil
+}
+
+func CreateConfigFile(username, password string) error {
+	configFilePath, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+
+	data := Config{
+		Username: username,
+		Password: password,
+	}
+	bytes, _ := json.Marshal(&data)
+
+	if err := os.MkdirAll(filepath.Dir(configFilePath), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(configFilePath, bytes, 0644)
+}
+
+func RemoveConfigFile() error {
+	configPath, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+
+	return os.RemoveAll(configPath)
 }


### PR DESCRIPTION
resolve: #46 

## 解決した不具合

-  `cvpn login` をした後に `cvpn login` をすると、1回目の login のキャッシュでログインチェックが行われてしまい、正確なチェックができないという不具合(#46 を参照)。

## 変更点

- モジュール分割を少しした。
